### PR TITLE
Fixed nested comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 compile_commands.json
 .idea
 build.sh
+test_scripts

--- a/src/literal.cpp
+++ b/src/literal.cpp
@@ -15,6 +15,7 @@ std::optional<std::string> literal_as_string(const Literal& literal)
             return std::nullopt;
         default:
             ErrorHandler::get_instance().debug_error("Not every type was handled");
+            return std::nullopt;
     }
 }
 

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -212,10 +212,16 @@ void Scanner::identifier()
 
 void Scanner::block_comment()
 {
-    while (peek() != '*' && !is_end())
+    while (peek() != '*')
     {
+        // if we run out of characters
+        if (is_end())
+        {
+            ErrorHandler::get_instance().error(m_line, "Unclosed block comment.");
+            return;
+        }
         if (peek() == '\n') m_line++;
-        // handle block comments
+        // handle nested comments
         if (peek_next() == '*')
             if (peek() == '/')
             {


### PR DESCRIPTION
Now if interpreter encounters unclosed block comments it is going to report an error
Now the function that converts literals to strings will return std::nullopt if it encounters a default case