### PR TITLE
Added comments

### DIFF
--- a/include/ast_printer.h
+++ b/include/ast_printer.h
@@ -14,6 +14,7 @@
 namespace garm
 {
 
+// Prints a syntax tree for a given expression
 class AstPrinter : public ast::Visitor
 {
 public:

--- a/include/syntax_tree/expression.h
+++ b/include/syntax_tree/expression.h
@@ -5,11 +5,14 @@
 
 namespace garm::ast
 {
+// Interface that every non-terminal in the grammar have to implement
 class Expression
 {
 public:
     virtual ~Expression() = default;
 
+    // Accepts a visitor that manipulates the data of this expression
+    // The proper `visit` functions are deduced by dynamic dispatch
     virtual Value accept(Visitor* visitor) = 0;
 };
 

--- a/include/syntax_tree/visitor.h
+++ b/include/syntax_tree/visitor.h
@@ -10,6 +10,7 @@ class Grouping;
 class Literal;
 class Unary;
 
+// Interface that represents an operation executed on the given expressions
 class Visitor
 {
 public:

--- a/include/value.h
+++ b/include/value.h
@@ -8,8 +8,11 @@
 
 namespace garm
 {
+
+// Value represents a literal value that some expressions can have - currently either a string or a double
 using Value = std::optional<std::variant<std::string, double>>;
 
+// Converts Value to string (it's used when printing tokens)
 std::optional<std::string> literal_as_string(const Value& literal);
 
 }

--- a/src/ast_printer.cpp
+++ b/src/ast_printer.cpp
@@ -49,7 +49,7 @@ std::string AstPrinter::parenthesize(const std::string& name, std::vector<std::s
                 break;
             default:
                 ErrorHandler::get_instance().debug_error("Not every type was handled");
-                return "";
+                break;
         }
     }
     out += ")";


### PR DESCRIPTION
Added comments
`parenthesize` method in `AstPrinter` now doesn't return when it encounters an unhandled variant