### PR TITLE
Added parser

### DIFF
--- a/include/ast_printer.h
+++ b/include/ast_printer.h
@@ -10,6 +10,7 @@
 #include "syntax_tree/grouping.h"
 #include "syntax_tree/literal.h"
 #include "syntax_tree/unary.h"
+#include "error_handler.h"
 
 namespace garm
 {
@@ -25,7 +26,7 @@ public:
     Value visit(ast::Literal* expr) override;
     Value visit(ast::Unary* expr) override;
 private:
-    std::string parenthesize(const std::string& name, std::vector<std::shared_ptr<ast::Expression>>&& exprs);
+    std::string parenthesize(const std::string& name, std::vector<ExpressionPtr>&& exprs);
 };
 }
 

--- a/include/error_handler.h
+++ b/include/error_handler.h
@@ -1,7 +1,10 @@
 #ifndef ERROR_HANDLER_H
 #define ERROR_HANDLER_H
 
+#include <exception>
 #include <iostream>
+
+#include "token.h"
 
 namespace garm
 {
@@ -17,7 +20,9 @@ public:
         return instance;
     }
 
+    void error(const types::Token& token, const std::string& msg);
     void error(unsigned int line, const std::string& msg);
+
     void debug_error(const std::string& msg);
 
     bool m_had_error = false;
@@ -27,6 +32,12 @@ private:
 
     void report(unsigned int line, const std::string& where, const std::string& msg);
 };
-}  // namespace garm
+
+class ParseError : public std::exception
+{
+public:
+    [[nodiscard]] const char* what() const noexcept override;
+};
+}
 
 #endif  // ERROR_HANDLER_H

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,0 +1,71 @@
+#ifndef PARSER_H
+#define PARSER_H
+
+#include <memory>
+#include <vector>
+
+#include "error_handler.h"
+#include "syntax_tree/binary.h"
+#include "syntax_tree/expression.h"
+#include "syntax_tree/grouping.h"
+#include "syntax_tree/literal.h"
+#include "syntax_tree/unary.h"
+#include "token.h"
+
+namespace garm
+{
+// Parser that uses recursive decent parsing method
+class Parser
+{
+public:
+    explicit Parser(std::vector<types::Token> tokens)
+        : m_tokens(std::move(tokens))
+    {
+    }
+
+    // Begins parsing
+    std::optional<ExpressionPtr> parse();
+
+private:
+    /*
+     * Methods that directly translate to the grammar rules
+     */
+
+    ExpressionPtr expression();
+    ExpressionPtr equality();
+    ExpressionPtr comparison();
+    ExpressionPtr term();
+    ExpressionPtr factor();
+    ExpressionPtr unary();
+    ExpressionPtr primary();
+
+    /*
+     * Utility functions
+     */
+
+    // Checks if the current token is of any of the given types. Consumes the token if the type matches
+    bool match(const std::vector<types::TokenType>&& types);
+    // Returns the current token and consumes it.
+    types::Token advance();
+    // Checks if the current token is of the given type, consumes it and returns it.
+    // If the types don't match an error is reported
+    types::Token consume(types::TokenType type, const std::string& msg);
+    // Checks if current token is of the given type.
+    [[nodiscard]] bool check(types::TokenType type) const;
+    // Returns the current token
+    [[nodiscard]] types::Token peek() const;
+    // Checks if the input has exhausted
+    [[nodiscard]] bool is_end() const;
+    // Returns the most recently consumed token
+    [[nodiscard]] types::Token previous() const;
+    // Reports an error and returns an exception
+    [[nodiscard]] ParseError error(const types::Token& token, const std::string& msg);
+    // Advances the input to the statement boundary in the process of error recovery
+    void synchronize();
+
+    const std::vector<types::Token> m_tokens;
+    unsigned int m_current = 0;
+};
+}
+
+#endif  // PARSER_H

--- a/include/scanner.h
+++ b/include/scanner.h
@@ -18,12 +18,13 @@ class Scanner
 {
 public:
     // scans file
-    void run_file(const std::string& filename);
+    std::optional<std::vector<Token>> run_file(const std::string& filename);
     // starts up an interactive prompt
     void run_prompt();
 
 private:
-    void run();
+    // scans the source string and returns a vector of tokens
+    std::vector<Token> run();
     // scan a string of characters and turn them into tokens
     std::vector<Token> scan_tokens();
     // scan an individual character and turn it into a token

--- a/include/syntax_tree/binary.h
+++ b/include/syntax_tree/binary.h
@@ -4,14 +4,16 @@
 #include "expression.h"
 #include "token.h"
 
+using ExpressionPtr = std::shared_ptr<garm::ast::Expression>;
+
 namespace garm::ast
 {
 class Binary : public Expression
 {
 public:
-    Binary(Expression* left, garm::types::Token* op, Expression* right)
+    Binary(const ExpressionPtr& left, const garm::types::Token& op, const ExpressionPtr& right)
         : m_left(left)
-        , m_op(op)
+        , m_op(std::make_shared<garm::types::Token>(op))
         , m_right(right)
     {
     }
@@ -21,9 +23,9 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Expression> m_left;
+    ExpressionPtr m_left;
     std::shared_ptr<garm::types::Token> m_op;
-    std::shared_ptr<Expression> m_right;
+    ExpressionPtr m_right;
 };
 
 }

--- a/include/syntax_tree/grouping.h
+++ b/include/syntax_tree/grouping.h
@@ -8,7 +8,7 @@ namespace garm::ast
 class Grouping : public Expression
 {
 public:
-    explicit Grouping(Expression* expression)
+    explicit Grouping(const ExpressionPtr& expression)
         : m_expression(expression)
     {
     }
@@ -18,7 +18,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Expression> m_expression;
+    ExpressionPtr m_expression;
 };
 
 }

--- a/include/syntax_tree/unary.h
+++ b/include/syntax_tree/unary.h
@@ -8,8 +8,8 @@ namespace garm::ast
 class Unary : public Expression
 {
 public:
-Unary(garm::types::Token* op, Expression* right)
-: m_op(op), m_right(right)
+Unary(const garm::types::Token& op, const ExpressionPtr& right)
+: m_op(std::make_shared<garm::types::Token>(op)), m_right(right)
 {}
 
 Value accept(Visitor* visitor) override
@@ -18,7 +18,7 @@ return visitor->visit(this);
 }
 
 std::shared_ptr<garm::types::Token> m_op;
-std::shared_ptr<Expression> m_right;
+ExpressionPtr m_right;
 };
 
 }

--- a/include/token.h
+++ b/include/token.h
@@ -1,8 +1,8 @@
 #ifndef TOKEN_TYPE_H
 #define TOKEN_TYPE_H
 
-#include <utility>
 #include <map>
+#include <utility>
 
 #include "value.h"
 
@@ -70,6 +70,7 @@ public:
     [[nodiscard]] std::string get_lexeme() const;
     [[nodiscard]] Value get_literal() const;
     [[nodiscard]] unsigned int get_line() const;
+
 private:
     static std::optional<std::string> token_to_string(TokenType token);
 
@@ -77,8 +78,7 @@ private:
     std::string m_lexeme;
     Value m_literal;
     unsigned int m_line;
-
 };
-}  // namespace garm::types
+}
 
 #endif  // TOKEN_TYPE_H

--- a/include/value.h
+++ b/include/value.h
@@ -3,14 +3,13 @@
 
 #include <optional>
 #include <variant>
-
-#include "error_handler.h"
+#include <iostream>
 
 namespace garm
 {
 
 // Value represents a literal value that some expressions can have - currently either a string or a double
-using Value = std::optional<std::variant<std::string, double>>;
+using Value = std::optional<std::variant<std::string, double, bool>>;
 
 // Converts Value to string (it's used when printing tokens)
 std::optional<std::string> literal_as_string(const Value& literal);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
- add_compile_options(-Wall -Wextra -pedantic -Wno-narrowing -Wno-sign-compare -O1)
+ add_compile_options(-Wall -Wextra -pedantic -Wno-narrowing -Wno-sign-compare )
 
- add_executable(garm main.cpp scanner.cpp error_handler.cpp token.cpp ast_printer.cpp value.cpp)
+ add_executable(garm main.cpp scanner.cpp error_handler.cpp token.cpp ast_printer.cpp value.cpp parser.cpp)

--- a/src/ast_printer.cpp
+++ b/src/ast_printer.cpp
@@ -30,7 +30,7 @@ Value AstPrinter::visit(ast::Unary* expr)
     return static_cast<Value>(parenthesize(expr->m_op->get_lexeme(), {expr->m_right}));
 }
 
-std::string AstPrinter::parenthesize(const std::string& name, std::vector<std::shared_ptr<ast::Expression>>&& exprs)
+std::string AstPrinter::parenthesize(const std::string& name, std::vector<ExpressionPtr>&& exprs)
 {
     std::string out = "(" + name;
 
@@ -46,6 +46,9 @@ std::string AstPrinter::parenthesize(const std::string& name, std::vector<std::s
                 break;
             case 1: //double
                 out += std::to_string(std::get<double>(val.value()));
+                break;
+            case 2: //bool
+                out += std::to_string(std::get<bool>(val.value()));
                 break;
             default:
                 ErrorHandler::get_instance().debug_error("Not every type was handled");

--- a/src/error_handler.cpp
+++ b/src/error_handler.cpp
@@ -2,6 +2,14 @@
 
 namespace garm
 {
+void ErrorHandler::error(const types::Token& token, const std::string& msg)
+{
+    if (token.get_token_type() == types::TokenType::GARM_EOF)
+        report(token.get_line(), " at end", msg);
+    else
+        report(token.get_line(), " at '" + token.get_lexeme() + "'", msg);
+}
+
 void ErrorHandler::error(unsigned int line, const std::string& msg)
 {
     report(line, "", msg);
@@ -19,4 +27,9 @@ void ErrorHandler::debug_error(const std::string& msg)
     std::cout << "Internal error at " << __FILE__ << " line" << __LINE__ << ": " << msg << '\n';
 }
 
-}  // namespace garm
+const char* ParseError::what() const noexcept
+{
+    return "ParseError: unexpected character.";
+}
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,23 +1,14 @@
-#include "scanner.h"
 #include "ast_printer.h"
+#include "scanner.h"
+#include "parser.h"
 #include "token.h"
 
 int main(int argc, char** argv)
 {
     using namespace garm;
 
-    ast::Literal left{static_cast<Value>(123)};
-    auto* op = new Token(TokenType::MINUS, "-", std::nullopt, 1);
-    ast::Literal right{static_cast<Value>(123)};
-
-    ast::Expression* expr1 = new ast::Binary(&left, op, &right);
-
+    Scanner scanner;
     AstPrinter printer;
-
-    std::cout << printer.print(expr1);
-
-    /*
-    garm::Scanner scanner;
 
     if (argc > 2)
     {
@@ -26,12 +17,24 @@ int main(int argc, char** argv)
     }
     else if (argc == 2)
     {
-        scanner.run_file(argv[1]);
+        auto tokens = scanner.run_file(argv[1]);
+        if(!tokens.has_value())
+        {
+            std::exit(-1);
+        }
+
+        Parser parser{tokens.value()};
+        ExpressionPtr expr = parser.parse().value();
+
+        /*std::cout << dynamic_cast<ast::Binary*>(expr.get())->m_right << '\n';
+        std::cout << dynamic_cast<ast::Binary*>(expr.get())->m_op << '\n';
+        std::cout << dynamic_cast<ast::Binary*>(expr.get())->m_left << '\n';
+         */
+        if (ErrorHandler::get_instance().m_had_error)
+            std::exit(-1);
+
+        std::cout << printer.print(expr.get());
     }
-    else
-    {
-        scanner.run_prompt();
-    }
-*/
+
     return 0;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,204 @@
+#include "parser.h"
+
+namespace garm
+{
+std::optional<ExpressionPtr> Parser::parse()
+{
+    try
+    {
+        return expression();
+    }
+    catch (ParseError&)
+    {
+        return std::nullopt;
+    }
+}
+
+ExpressionPtr Parser::expression()
+{
+    return equality();
+}
+
+ExpressionPtr Parser::equality()
+{
+    ExpressionPtr expr = comparison();
+
+    while (match({types::TokenType::BANG_EQUAL, types::TokenType::EQUAL_EQUAL}))
+    {
+        types::Token op = previous();
+        ExpressionPtr right = comparison();
+        expr = std::make_shared<ast::Binary>(expr, op, right);
+    }
+
+    return expr;
+}
+
+ExpressionPtr Parser::comparison()
+{
+    ExpressionPtr expr = term();
+
+    while (match({types::TokenType::LESS, types::TokenType::LESS_EQUAL, types::TokenType::GREATER,
+                  types::TokenType::GREATER_EQUAL}))
+    {
+        types::Token op = previous();
+        ExpressionPtr right = term();
+        expr = std::make_shared<ast::Binary>(expr, op, right);
+    }
+
+    return expr;
+}
+
+ExpressionPtr Parser::term()
+{
+    ExpressionPtr expr = factor();
+
+    while (match({types::TokenType::PLUS, types::TokenType::MINUS}))
+    {
+        types::Token op = previous();
+        ExpressionPtr right = factor();
+        expr = std::make_shared<ast::Binary>(expr, op, right);
+    }
+
+    return expr;
+}
+
+ExpressionPtr Parser::factor()
+{
+    ExpressionPtr expr = unary();
+
+    while (match({types::TokenType::SLASH, types::TokenType::STAR}))
+    {
+        types::Token op = previous();
+        ExpressionPtr right = unary();
+        expr = std::make_shared<ast::Binary>(expr, op, right);
+    }
+
+    return expr;
+}
+
+ExpressionPtr Parser::unary()
+{
+    if (match({types::TokenType::BANG, types::TokenType::MINUS}))
+    {
+        types::Token op = previous();
+        ExpressionPtr right = unary();
+
+        return std::make_shared<ast::Unary>(op, right);
+    }
+
+    return primary();
+}
+
+ExpressionPtr Parser::primary()
+{
+    if (match({types::TokenType::FALSE})) return std::make_shared<ast::Literal>(false);
+    if (match({types::TokenType::TRUE})) return std::make_shared<ast::Literal>(true);
+    if (match({types::TokenType::NIL})) return std::make_shared<ast::Literal>(std::nullopt);
+
+    if (match({types::TokenType::STRING, types::TokenType::NUMBER}))
+    {
+        return std::make_shared<ast::Literal>(previous().get_literal());
+    }
+
+    if (match({types::TokenType::LEFT_PAREN}))
+    {
+        ExpressionPtr mid_expr = expression();
+
+        consume(types::TokenType::RIGHT_PAREN, "Expect ')' after expression.");
+
+        // TODO: uncomment when you implement statements
+        /*try {
+            consume(types::TokenType::RIGHT_PAREN, "Expect ')' after expression.");
+        }
+        catch (ParseError&)
+        {
+            synchronize();
+        }*/
+
+        return std::make_shared<ast::Grouping>(mid_expr);
+    }
+
+    // Failed to find any rule to parse the token
+    throw error(peek(), "Expect expression.");
+}
+
+bool Parser::match(const std::vector<types::TokenType>&& types)
+{
+    for (const auto& type : types)
+    {
+        if (check(type))
+        {
+            advance();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+types::Token Parser::advance()
+{
+    if (!is_end()) m_current++;
+    return previous();
+}
+
+types::Token Parser::consume(types::TokenType type, const std::string& msg)
+{
+    if (check(type)) return advance();
+
+    throw error(peek(), msg);
+}
+
+bool Parser::check(types::TokenType type) const
+{
+    if (is_end()) return false;
+    return peek().get_token_type() == type;
+}
+
+types::Token Parser::peek() const
+{
+    return m_tokens.at(m_current);
+}
+
+bool Parser::is_end() const
+{
+    return peek().get_token_type() == types::TokenType::GARM_EOF;
+}
+
+types::Token Parser::previous() const
+{
+    return m_tokens.at(m_current - 1);
+}
+
+ParseError Parser::error(const types::Token& token, const std::string& msg)
+{
+    ErrorHandler::get_instance().error(token, msg);
+    return ParseError{};
+}
+
+void Parser::synchronize()
+{
+    advance();
+
+    while (!is_end())
+    {
+        if (previous().get_token_type() == types::TokenType::SEMICOLON) return;
+
+        switch (peek().get_token_type())
+        {
+            case types::TokenType::CLASS:
+            case types::TokenType::FUN:
+            case types::TokenType::VAR:
+            case types::TokenType::FOR:
+            case types::TokenType::IF:
+            case types::TokenType::WHILE:
+            case types::TokenType::PRINT:
+            case types::TokenType::RETURN:
+                return;
+        }
+
+        advance();
+    }
+}
+
+}

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -2,7 +2,7 @@
 
 namespace garm
 {
-void Scanner::run_file(const std::string& filename)
+std::optional<std::vector<Token>> Scanner::run_file(const std::string& filename)
 {
     try
     {
@@ -15,14 +15,14 @@ void Scanner::run_file(const std::string& filename)
         m_source = sstream.str();
 
         // scan the m_source that contains the script file contents
-        run();
+        return run();
 
-        if (ErrorHandler::get_instance().m_had_error) std::exit(65);
+        //if (ErrorHandler::get_instance().m_had_error) std::exit(65);
     }
     catch (std::ifstream::failure& e)
     {
         std::cout << "Error: failed to open script file - " << e.what() << '\n';
-        return;
+        return std::nullopt;
     }
 }
 
@@ -44,13 +44,9 @@ void Scanner::run_prompt()
     }
 }
 
-void Scanner::run()
+std::vector<Token> Scanner::run()
 {
-    std::vector<Token> tokens = scan_tokens();
-    for (const Token& token : tokens)
-    {
-        std::cout << token.get_lexeme();
-    }
+    return scan_tokens();
 }
 
 std::vector<Token> Scanner::scan_tokens()

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -64,11 +64,8 @@ std::optional<std::string> Token::token_to_string(TokenType token)
     {
         return token_lookup.find(token)->second;
     }
-    else
-    {
-        ErrorHandler::get_instance().debug_error("Invalid token.");
-        return std::nullopt;
-    }
+
+    return std::nullopt;
 }
 
 TokenType Token::get_token_type() const
@@ -91,4 +88,4 @@ unsigned int Token::get_line() const
     return m_line;
 }
 
-}  // namespace garm::types
+}

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -15,7 +15,7 @@ std::optional<std::string> literal_as_string(const Value& literal)
         case std::variant_npos:  // nothing
             return std::nullopt;
         default:
-            ErrorHandler::get_instance().debug_error("Not every type was handled");
+            std::cout << "Error: not every type was handled.";
             return std::nullopt;
     }
 }


### PR DESCRIPTION
Added a parser that turns a sequence of tokens into an `Expression`
Changed raw pointers to smart pointers in constructor parameters of ast classes like `Binary`
Added alias `ExpressionPtr` that replaces `std::shared_ptr<Expression>`
`Scanner::run_file()` now returns a vector of tokens (or `std::nullopt` in case it couldn't scan the file)
Added new `ErrorHandler::error()` method that prints additional information about the token that caused the error
Removed error reporting from `Token:token_to_string()` and `literal_as_string()` because it caused some circular dependency issues
Added an exception class `ParseError`
`AstPrinter::parenthesize()` now also handles the case where the literal value is of type `bool`
Disabled -O1 optimizations