### PR TITLE
Fixed !=  operator

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -98,11 +98,9 @@ Value Interpreter::visit(ast::Binary *expr)
         case types::TokenType::LESS_EQUAL:
             check_number_operands(*expr->m_op, left, right);
             return dleft <= dright;
-        case types::TokenType::BANG:
-            check_number_operands(*expr->m_op, left, right);
+        case types::TokenType::BANG_EQUAL:
             return !is_equal(left, right);
         case types::TokenType::EQUAL_EQUAL:
-            check_number_operands(*expr->m_op, left, right);
             return is_equal(left, right);
     }
 


### PR DESCRIPTION
It was meant to be `BANG_EQUAL` and not `BANG`. It caused an error when using != operator.