### PR TITLE
Added number and string concatenation, error throwing on division by zero

### DIFF
--- a/include/value.h
+++ b/include/value.h
@@ -14,7 +14,12 @@ using Value = std::optional<std::variant<std::string, double, bool>>;
 // Converts Value to string (it's used when printing tokens)
 std::optional<std::string> literal_as_string(const Value& literal);
 
+// Prints the value
 std::ostream& operator<<(std::ostream& stream, const Value& val);
+
+// Trims trailing zeroes from the end of the string
+std::string trim_zeroes(const std::string& str);
+
 }
 
 #endif  // VALUE_H

--- a/src/error_handler.cpp
+++ b/src/error_handler.cpp
@@ -28,7 +28,7 @@ void ErrorHandler::error(unsigned int line, const std::string& msg)
 
 void ErrorHandler::runtime_error(const RuntimeError& error)
 {
-    std::cout << error.m_msg << "\n[line " + std::to_string(error.m_op.get_line()) << "]";
+    std::cout << error.m_msg << " [line " + std::to_string(error.m_op.get_line()) << "]";
     m_had_runtime_error = true;
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -34,12 +34,7 @@ std::ostream& operator<<(std::ostream& stream, const Value& val)
         case 1:
         {
             std::string text = std::to_string(std::get<double>(val.value()));
-
-            // trim unnecessary zeroes
-            if (text.ends_with(".000000"))
-            {
-                text = text.substr(0, text.size() - 7);
-            }
+            text = trim_zeroes(text);
             return stream << text;
         }
         case 2:
@@ -54,6 +49,16 @@ std::ostream& operator<<(std::ostream& stream, const Value& val)
             std::cout << "Error: not every type was handled.";
             return stream;
     }
+}
+
+std::string trim_zeroes(const std::string& str)
+{
+    if (str.ends_with(".000000"))
+    {
+        return str.substr(0, str.size() - 7);
+    }
+
+    return str;
 }
 
 }


### PR DESCRIPTION
Added number and string concatenation, error throwing on division by zero

If one of the values is a string, the other one is converted to string and concatenated (when using + operation)
Added method `trim_zeroes()` to `value.h` that removes the trailing zeroes
When you divide by zero a `RuntimeError` is thrown
Changed how runtime errors are displayed