### PR TITLE
Fixed a bug associated with fixing_closures

### DIFF
--- a/include/callable.h
+++ b/include/callable.h
@@ -2,6 +2,7 @@
 #define CALLABLE_H
 
 #include <vector>
+#include <string>
 
 namespace cpplox
 {
@@ -15,7 +16,8 @@ public:
     virtual ~Callable() = default;
     virtual Value call(Interpreter* interpreter, const std::vector<Value>& args) = 0;
     // returns number of arguments
-    [[nodiscard]] virtual unsigned int arity() const = 0;
+    [[nodiscard]] virtual int arity() const = 0;
+    [[nodiscard]] virtual std::string to_string() const = 0;
 };
 
 }

--- a/include/environment.h
+++ b/include/environment.h
@@ -23,13 +23,22 @@ public:
     }
 
     void define(const std::string& name, const Value& val);
-    Value get(const Token& name);
+    Value get(const Token& name) const;
+    Value get_at(int distance, const std::string& name);
     void assign(const Token& name, const Value& val);
+    void assign_at(int distance, const Token& name, const Value& val);
+
+    [[nodiscard]] inline std::unordered_map<std::string, Value> get_values() const
+    {
+        return m_values;
+    }
 
     // outer scope
     std::shared_ptr<Environment> m_enclosing;
 
 private:
+    std::shared_ptr<Environment> ancestor(int distance) const;
+
     std::unordered_map<std::string, Value> m_values;
 };
 

--- a/include/error_handler.h
+++ b/include/error_handler.h
@@ -19,7 +19,7 @@ public:
 class RuntimeError : public std::exception
 {
 public:
-    explicit RuntimeError(Token op, std::string msg)
+    RuntimeError(Token op, std::string msg)
         : m_op(std::move(op))
         , m_msg(std::move(msg))
     {
@@ -44,11 +44,12 @@ public:
     }
 
     void error(const Token& token, const std::string& msg);
-    void error(unsigned int line, unsigned int column, char character, const std::string& src_str,
+    void error(int line, int column, char character, const std::string& src_str,
                const std::string& msg);
     void runtime_error(const RuntimeError& error);
+    void debug_error(const std::string& msg, int line);
 
-    void debug_error(const std::string& msg);
+    void warning(const std::string& msg) const;
 
     bool m_had_error = false;
     bool m_had_runtime_error = false;
@@ -58,7 +59,7 @@ private:
 
     std::string format_error(const Token& token);
 
-    void report(unsigned int line, unsigned int column, const std::string& where, const std::string& src_str,
+    void report(int line, int column, const std::string& where, const std::string& src_str,
                 const std::string& msg);
 };
 

--- a/include/function.h
+++ b/include/function.h
@@ -18,8 +18,8 @@ public:
     }
 
     Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
-    [[nodiscard]] unsigned int arity() const override;
-    [[nodiscard]] std::string to_string() const;
+    [[nodiscard]] int arity() const override;
+    [[nodiscard]] std::string to_string() const override;
 
 private:
     std::shared_ptr<ast::stmt::Function> m_declaration;

--- a/include/lambda.h
+++ b/include/lambda.h
@@ -16,8 +16,8 @@ public:
     }
 
     Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
-    [[nodiscard]] unsigned int arity() const override;
-    [[nodiscard]] std::string to_string() const;
+    [[nodiscard]] int arity() const override;
+    [[nodiscard]] std::string to_string() const override;
 
 private:
     std::shared_ptr<ast::expr::Lambda> m_declaration;

--- a/include/native_functions/println.h
+++ b/include/native_functions/println.h
@@ -1,17 +1,19 @@
-#ifndef CLOCK_FN_H
-#define CLOCK_FN_H
+#ifndef PRINTLN_FN_H
+#define PRINTLN_FN_H
 
-#include <chrono>
-
+#include "fmt/core.h"
 #include "callable.h"
 #include "value.h"
 
 namespace cpplox
 {
 /*
- * Returns time passed since epoch.
+ * Prints 'str' with a newline character after it
+ *
+ * 'str': a string to print
+ *
  */
-class ClockFunction : public Callable
+class PrintlnFunction : public Callable
 {
 public:
     Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
@@ -20,4 +22,4 @@ public:
 };
 }
 
-#endif  // CLOCK_FN_H
+#endif  // PRINTLN_FN_H

--- a/include/parser.h
+++ b/include/parser.h
@@ -84,7 +84,7 @@ private:
     void synchronize();
 
     const std::vector<Token> m_tokens;
-    unsigned int m_current = 0;
+    int m_current = 0;
 };
 }
 

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -1,0 +1,77 @@
+#ifndef RESOLVER_H
+#define RESOLVER_H
+
+#include <deque>
+#include <unordered_map>
+
+#include "error_handler.h"
+#include "interpreter.h"
+#include "syntax_tree/expression.h"
+#include "syntax_tree/statement.h"
+
+namespace cpplox
+{
+using namespace ast;
+
+// strings are variable names
+// bools indicate whether we have finished resolving the variable's initializer
+using Scope = std::unordered_map<std::string, bool>;
+
+// Resolves variable bindings (except global variables)
+class Resolver : public stmt::Visitor, expr::Visitor
+{
+    enum class FunctionType
+    {
+        NONE,
+        FUNCTION
+    };
+
+public:
+    explicit Resolver(const std::shared_ptr<Interpreter>& interpreter)
+        : m_interpreter(interpreter)
+    {
+    }
+
+    void visit(stmt::Block* stmt) override;
+    void visit(stmt::Var* stmt) override;
+    void visit(stmt::Function* stmt) override;
+    void visit(stmt::Expression* stmt) override;
+    void visit(stmt::If* stmt) override;
+    void visit(stmt::Print* stmt) override;
+    void visit(stmt::Return* stmt) override;
+    void visit(stmt::While* stmt) override;
+
+    Value visit(expr::Variable* expr) override;
+    Value visit(expr::Assign* expr) override;
+    Value visit(expr::Lambda* expr) override;
+    Value visit(expr::Binary* expr) override;
+    Value visit(expr::Call* expr) override;
+    Value visit(expr::Grouping* expr) override;
+    Value visit(expr::Literal* expr) override;
+    Value visit(expr::Logical* expr) override;
+    Value visit(expr::Unary* expr) override;
+
+    void resolve(const std::vector<StatementPtr>& stmts);
+
+private:
+    void resolve(stmt::Statement* stmt);
+    void resolve(expr::Expression* expr);
+    void resolve_local(expr::Expression* expr, const Token& name);
+    void resolve_function(stmt::Function* function, FunctionType type);
+
+    void begin_scope();
+    void end_scope();
+
+    void declare(const Token& name);
+    void define(const Token& name);
+
+    // scopes that are currently in scope
+    std::deque<Scope> m_scopes;
+    std::weak_ptr<Interpreter> m_interpreter;
+
+    FunctionType m_current_func = FunctionType::NONE;
+};
+
+}
+
+#endif  // RESOLVER_H

--- a/include/scanner.h
+++ b/include/scanner.h
@@ -35,7 +35,7 @@ private:
     void identifier();
     void block_comment();
 
-    void add_token(TokenType type, const Value& literal);
+    void add_token(TokenType type, const Value& literal = std::nullopt);
     // returns true if scanner is at the end of file
     [[nodiscard]] bool is_end() const;
     // returns true if the next char in the input equals *expected*
@@ -48,22 +48,24 @@ private:
     char peek_next();
     // updates `m_str_line`
     void update_source_line();
+    // updates `m_column`
+    void update_column();
 
     static std::optional<TokenType> str_to_keyword(const std::string& str);
 
     std::vector<Token> m_tokens;
 
     // start of the current token
-    unsigned int m_start = 0;
+    int m_start = 0;
     // current index into the source string
-    unsigned int m_current = 0;
+    int m_current = 0;
     // current line
-    unsigned int m_line = 1;
+    int m_line = 1;
     // current line as a string
     std::string m_str_line;
     // the character at which a new line starts
-    unsigned int m_new_line = 0;
-    unsigned int m_column = 0;
+    int m_new_line = 0;
+    int m_column = 0;
 
     std::string m_source;
 };

--- a/include/syntax_tree/expression.h
+++ b/include/syntax_tree/expression.h
@@ -72,7 +72,7 @@ class Binary : public Expression
 public:
     Binary(const std::shared_ptr<Expression>& left, const Token& op, const std::shared_ptr<Expression>& right)
         : m_left(left)
-        , m_op(std::make_shared<Token>(op))
+        , m_op(op)
         , m_right(right)
     {
     }
@@ -83,7 +83,7 @@ public:
     }
 
     std::shared_ptr<Expression> m_left;
-    std::shared_ptr<Token> m_op;
+    Token m_op;
     std::shared_ptr<Expression> m_right;
 };
 
@@ -107,7 +107,7 @@ class Unary : public Expression
 {
 public:
     Unary(const Token& op, const std::shared_ptr<Expression>& right)
-        : m_op(std::make_shared<Token>(op))
+        : m_op(op)
         , m_right(right)
     {
     }
@@ -117,7 +117,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_op;
+    Token m_op;
     std::shared_ptr<Expression> m_right;
 };
 
@@ -125,7 +125,7 @@ class Variable : public Expression
 {
 public:
     explicit Variable(const Token& name)
-        : m_name(std::make_shared<Token>(name))
+        : m_name(name)
     {
     }
 
@@ -134,14 +134,14 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_name;
+    Token m_name;
 };
 
 class Assign : public Expression
 {
 public:
     Assign(const Token& name, const std::shared_ptr<Expression>& value)
-        : m_name(std::make_shared<Token>(name))
+        : m_name(name)
         , m_value(value)
     {
     }
@@ -151,7 +151,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_name;
+    Token m_name;
     std::shared_ptr<Expression> m_value;
 };
 
@@ -160,7 +160,7 @@ class Logical : public Expression
 public:
     Logical(const std::shared_ptr<Expression>& left, const Token& op, const std::shared_ptr<Expression>& right)
         : m_left(left)
-        , m_op(std::make_shared<Token>(op))
+        , m_op(op)
         , m_right(right)
     {
     }
@@ -171,7 +171,7 @@ public:
     }
 
     std::shared_ptr<Expression> m_left;
-    std::shared_ptr<Token> m_op;
+    Token m_op;
     std::shared_ptr<Expression> m_right;
 };
 
@@ -181,7 +181,7 @@ public:
     Call(const std::shared_ptr<Expression>& callee, const Token& paren,
          const std::vector<std::shared_ptr<Expression>>& args)
         : m_callee(callee)
-        , m_paren(std::make_shared<Token>(paren))
+        , m_paren(paren)
         , m_args(args)
     {
     }
@@ -193,14 +193,14 @@ public:
 
     // callee is the thing being called
     std::shared_ptr<Expression> m_callee;
-    std::shared_ptr<Token> m_paren;
+    Token m_paren;
     std::vector<std::shared_ptr<Expression>> m_args;
 };
 
 class Lambda : public Expression
 {
 public:
-    Lambda(const std::vector<std::shared_ptr<Token>>& params, const std::vector<std::shared_ptr<cpplox::ast::stmt::Statement>>& body)
+    Lambda(const std::vector<Token>& params, const std::vector<std::shared_ptr<cpplox::ast::stmt::Statement>>& body)
         : m_params(params)
         , m_body(body)
     {
@@ -211,7 +211,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::vector<std::shared_ptr<Token>> m_params;
+    std::vector<Token> m_params;
     std::vector<std::shared_ptr<cpplox::ast::stmt::Statement>> m_body;
 };
 

--- a/include/syntax_tree/statement.h
+++ b/include/syntax_tree/statement.h
@@ -81,7 +81,7 @@ public:
     // so it takes std::optional to indicate that.
     // If a variable is not initialized just pass std::nullopt
     Var(const Token& name, const std::optional<std::shared_ptr<expr::Expression>>& initializer)
-        : m_name(std::make_shared<Token>(name))
+        : m_name(name)
         , m_initializer(initializer)
     {
     }
@@ -91,7 +91,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_name;
+    Token m_name;
     std::optional<std::shared_ptr<expr::Expression>> m_initializer;
 };
 
@@ -153,9 +153,9 @@ public:
 class Function : public Statement
 {
 public:
-    Function(const Token& name, const std::vector<std::shared_ptr<Token>>& params,
+    Function(const Token& name, const std::vector<Token>& params,
              const std::vector<std::shared_ptr<Statement>>& body)
-        : m_name(std::make_shared<Token>(name))
+        : m_name(name)
         , m_params(params)
         , m_body(body)
     {
@@ -166,8 +166,8 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_name;
-    std::vector<std::shared_ptr<Token>> m_params;
+    Token m_name;
+    std::vector<Token> m_params;
     std::vector<std::shared_ptr<Statement>> m_body;
 };
 
@@ -175,7 +175,7 @@ class Return : public Statement
 {
 public:
     Return(const Token& keyword, const std::optional<ExpressionPtr>& value)
-        : m_keyword(std::make_shared<Token>(keyword))
+        : m_keyword(keyword)
         , m_value(value)
     {
     }
@@ -185,7 +185,7 @@ public:
         return visitor->visit(this);
     }
 
-    std::shared_ptr<Token> m_keyword;
+    Token m_keyword;
     std::optional<ExpressionPtr> m_value;
 };
 }

--- a/include/token.h
+++ b/include/token.h
@@ -62,8 +62,8 @@ enum class TokenType
 class Token
 {
 public:
-    Token(TokenType type, std::string lexeme, Value literal, unsigned int line, const std::string& str_line,
-          unsigned int column)
+    Token(TokenType type, std::string lexeme, Value literal, int line, const std::string& str_line,
+          int column)
         : m_token_type(type)
         , m_lexeme(std::move(lexeme))
         , m_literal(std::move(literal))
@@ -85,7 +85,7 @@ public:
     {
         return m_literal;
     }
-    [[nodiscard]] inline unsigned int get_line() const
+    [[nodiscard]] inline int get_line() const
     {
         return m_line;
     }
@@ -93,7 +93,7 @@ public:
     {
         return m_str_line;
     }
-    [[nodiscard]] inline unsigned int get_column() const
+    [[nodiscard]] inline int get_column() const
     {
         return m_column;
     }
@@ -102,10 +102,10 @@ private:
     TokenType m_token_type;
     std::string m_lexeme;
     Value m_literal;
-    unsigned int m_line;
+    int m_line;
     // used to print a line that had an error
     std::string m_str_line;
-    unsigned int m_column;
+    int m_column;
 };
 }
 

--- a/include/value.h
+++ b/include/value.h
@@ -15,7 +15,7 @@ using Val = std::optional<std::variant<std::string, double, bool, std::shared_pt
 class Value
 {
 public:
-    // don't make constructors explicit - we need implicit conversion
+    // don't make constructors explicit - we need implicit conversion (except for bools)
     Value(std::nullopt_t)
         : m_value(std::nullopt)
     {
@@ -28,7 +28,7 @@ public:
         : m_value(value)
     {
     }
-    Value(const bool& value)
+    explicit Value(const bool& value)
         : m_value(value)
     {
     }
@@ -39,6 +39,7 @@ public:
 
     // Prints the value
     friend std::ostream& operator<<(std::ostream& stream, const Value& val);
+    [[nodiscard]] std::string to_string() const;
 
     Val m_value;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
- target_sources(cpplox PRIVATE main.cpp scanner.cpp error_handler.cpp value.cpp parser.cpp interpreter.cpp environment.cpp function.cpp lambda.cpp)
+ target_sources(cpplox PRIVATE main.cpp scanner.cpp error_handler.cpp value.cpp parser.cpp interpreter.cpp environment.cpp function.cpp lambda.cpp resolver.cpp)
 
  add_subdirectory(native_functions)

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -10,7 +10,7 @@ void Environment::define(const std::string &name, const Value &val)
     m_values.insert({name, val});
 }
 
-Value Environment::get(const Token &name)
+Value Environment::get(const Token &name) const
 {
     auto element = m_values.find(name.get_lexeme());
     if (element != m_values.end())
@@ -23,10 +23,15 @@ Value Environment::get(const Token &name)
     throw RuntimeError{name, "Undefined variable '" + name.get_lexeme() + "'."};
 }
 
+Value Environment::get_at(int distance, const std::string &name)
+{
+    return ancestor(distance)->m_values.at(name);
+}
+
 void Environment::assign(const Token &name, const Value &val)
 {
     auto variable = m_values.find(name.get_lexeme());
-    if(variable != m_values.end())
+    if (variable != m_values.end())
     {
         variable->second = val;
         return;
@@ -40,6 +45,22 @@ void Environment::assign(const Token &name, const Value &val)
     }
 
     throw RuntimeError{name, "Undefined variable '" + name.get_lexeme() + "'."};
+}
+
+void Environment::assign_at(int distance, const Token &name, const Value &val)
+{
+    ancestor(distance)->m_values.emplace(name.get_lexeme(), val);
+}
+
+std::shared_ptr<Environment> Environment::ancestor(int distance) const
+{
+    auto env = std::make_shared<Environment>(*this);
+    for (int i = 0; i < distance; i++)
+    {
+        env = env->m_enclosing;
+    }
+
+    return env;
 }
 
 }

--- a/src/error_handler.cpp
+++ b/src/error_handler.cpp
@@ -22,7 +22,7 @@ void ErrorHandler::error(const Token& token, const std::string& msg)
         report(token.get_line(), token.get_column(), "at '" + token.get_lexeme() + "'", formatted_line, msg);
 }
 
-void ErrorHandler::error(unsigned int line, unsigned int column, char character, const std::string& src_str,
+void ErrorHandler::error(int line, int column, char character, const std::string& src_str,
                          const std::string& msg)
 {
     report(line, column, std::string(1, character), src_str, msg);
@@ -34,9 +34,17 @@ void ErrorHandler::runtime_error(const RuntimeError& error)
     m_had_runtime_error = true;
 }
 
-void ErrorHandler::debug_error(const std::string& msg)
+void ErrorHandler::debug_error(const std::string& msg, int line)
 {
-    std::cout << "Internal error at " << __FILE__ << " line" << __LINE__ << ": " << msg << '\n';
+    fmt::print("\n[line {}]", line);
+    fmt::print(fmt::emphasis::italic | fg(fmt::color::red), " Internal error in ");
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::deep_pink), "{}:\n\n", __FILE__);
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::white), "\t{}\n\n", msg);
+}
+
+void ErrorHandler::warning(const std::string& msg) const
+{
+    fmt::print(fmt::emphasis::italic | fg(fmt::color::yellow), " Warning: {}\n\n", msg);
 }
 
 std::string ErrorHandler::format_error(const Token& token)
@@ -47,7 +55,7 @@ std::string ErrorHandler::format_error(const Token& token)
     // because I wanted the token to be colored differently from the rest of the line
 
     // part of the line before the token that caused the error
-    unsigned int column = token.get_column();
+    int column = token.get_column();
     std::string before_token_line =
         fmt::format(fg(fmt::color::dark_olive_green), "{}", source_line.substr(0, column - token.get_lexeme().size()));
     std::string token_str = fmt::format(fg(fmt::color::red), "{}", token.get_lexeme());
@@ -57,10 +65,10 @@ std::string ErrorHandler::format_error(const Token& token)
     return before_token_line + token_str + after_token_line;
 }
 
-void ErrorHandler::report(unsigned int line, unsigned int column, const std::string& where, const std::string& src_str,
+void ErrorHandler::report(int line, int column, const std::string& where, const std::string& src_str,
                           const std::string& msg)
 {
-    fmt::print("[{}, {}]", line, column);
+    fmt::print("\n[{}, {}]", line, column);
     fmt::print(fmt::emphasis::italic | fg(fmt::color::red), " Error {}: {}\n\n", where, msg);
     fmt::print(fg(fmt::color::dark_olive_green), "\t{}\n\n", src_str);
     m_had_error = true;

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -1,4 +1,5 @@
 #include "function.h"
+
 #include "interpreter.h"
 
 namespace cpplox
@@ -9,7 +10,7 @@ Value Function::call(Interpreter *interpreter, const std::vector<Value> &args)
 
     for (int i = 0; i < m_declaration->m_params.size(); i++)
     {
-        env->define(m_declaration->m_params.at(i)->get_lexeme(), args.at(i));
+        env->define(m_declaration->m_params.at(i).get_lexeme(), args.at(i));
     }
 
     // bad. bad. bad
@@ -17,21 +18,21 @@ Value Function::call(Interpreter *interpreter, const std::vector<Value> &args)
     {
         interpreter->execute_block(m_declaration->m_body, env);
     }
-    catch(Return& return_value)
+    catch (Return &return_value)
     {
         return return_value.m_value;
     }
     return std::nullopt;
 }
 
-unsigned int Function::arity() const
+int Function::arity() const
 {
     return m_declaration->m_params.size();
 }
 
 std::string Function::to_string() const
 {
-    return "<fn " + m_declaration->m_name->get_lexeme();
+    return "<fn " + m_declaration->m_name.get_lexeme() + ">";
 }
 
 }

--- a/src/lambda.cpp
+++ b/src/lambda.cpp
@@ -10,7 +10,7 @@ Value Lambda::call(Interpreter *interpreter, const std::vector<Value> &args)
 
     for (int i = 0; i < m_declaration->m_params.size(); i++)
     {
-        env->define(m_declaration->m_params.at(i)->get_lexeme(), args.at(i));
+        env->define(m_declaration->m_params.at(i).get_lexeme(), args.at(i));
     }
 
     // bad. bad. bad
@@ -25,7 +25,7 @@ Value Lambda::call(Interpreter *interpreter, const std::vector<Value> &args)
     return std::nullopt;
 }
 
-unsigned int Lambda::arity() const
+int Lambda::arity() const
 {
     return m_declaration->m_params.size();
 }

--- a/src/native_functions/CMakeLists.txt
+++ b/src/native_functions/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(cpplox PRIVATE clock_fn.cpp)
+target_sources(cpplox PRIVATE clock_fn.cpp println.cpp)

--- a/src/native_functions/clock_fn.cpp
+++ b/src/native_functions/clock_fn.cpp
@@ -10,7 +10,7 @@ Value ClockFunction::call(Interpreter *interpreter, const std::vector<Value>& ar
     return static_cast<double>(value.count());
 }
 
-unsigned int ClockFunction::arity() const
+int ClockFunction::arity() const
 {
     // `clock()` receives 0 arguments, thus we return 0
     return 0;

--- a/src/native_functions/println.cpp
+++ b/src/native_functions/println.cpp
@@ -1,0 +1,21 @@
+#include "native_functions/println.h"
+
+namespace cpplox
+{
+
+Value PrintlnFunction::call(Interpreter *interpreter, const std::vector<Value>& args)
+{
+    fmt::print("{}\n", args[0].to_string());
+    return std::nullopt;
+}
+
+int PrintlnFunction::arity() const
+{
+    return 1;
+}
+
+std::string PrintlnFunction::to_string() const
+{
+    return "<fn println>";
+}
+}

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,14 +28,14 @@ ExpressionPtr Parser::expression()
 ExpressionPtr Parser::lambda()
 {
     consume(TokenType::LEFT_PAREN, "Expect '(' after 'fun' in lambda.");
-    std::vector<std::shared_ptr<Token>> params;
+    std::vector<Token> params;
     if (!check(TokenType::RIGHT_PAREN))
     {
         do
         {
             if (params.size() >= 255) error(peek(), "Can't have more than 255 parameters.");
 
-            auto token = std::make_shared<Token>(consume(TokenType::IDENTIFIER, "Expect parameter name."));
+            auto token = consume(TokenType::IDENTIFIER, "Expect parameter name.");
             params.emplace_back(token);
         } while (match({TokenType::COMMA}));
     }
@@ -59,7 +59,7 @@ ExpressionPtr Parser::assignment()
 
         if (typeid(*expr) == typeid(expr::Variable))
         {
-            Token name = *std::dynamic_pointer_cast<expr::Variable>(expr)->m_name;
+            Token name = std::dynamic_pointer_cast<expr::Variable>(expr)->m_name;
             return std::make_shared<expr::Assign>(name, value);
         }
 
@@ -248,14 +248,14 @@ StatementPtr Parser::function(const std::string& kind)
     Token name = consume(TokenType::IDENTIFIER, "Expect " + kind + " name.");
 
     consume(TokenType::LEFT_PAREN, "Expect '(' after " + kind + " name.");
-    std::vector<std::shared_ptr<Token>> params;
+    std::vector<Token> params;
     if (!check(TokenType::RIGHT_PAREN))
     {
         do
         {
             if (params.size() >= 255) error(peek(), "Can't have more than 255 parameters.");
 
-            auto token = std::make_shared<Token>(consume(TokenType::IDENTIFIER, "Expect parameter name."));
+            auto token = consume(TokenType::IDENTIFIER, "Expect parameter name.");
             params.emplace_back(token);
         } while (match({TokenType::COMMA}));
     }

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1,0 +1,239 @@
+#include "resolver.h"
+
+namespace cpplox
+{
+void Resolver::visit(stmt::Block *stmt)
+{
+    begin_scope();
+    resolve(stmt->m_statements);
+    end_scope();
+}
+
+void Resolver::visit(stmt::Var *stmt)
+{
+    declare(stmt->m_name);
+    if (stmt->m_initializer.has_value())
+    {
+        resolve(stmt->m_initializer->get());
+    }
+    define(stmt->m_name);
+}
+
+void Resolver::visit(stmt::Function *stmt)
+{
+    // we declare and immediately define the function,
+    // because it allows recursion
+    declare(stmt->m_name);
+    define(stmt->m_name);
+
+    resolve_function(stmt, FunctionType::FUNCTION);
+}
+
+void Resolver::visit(stmt::Expression *stmt)
+{
+    resolve(stmt->m_expr.get());
+}
+
+void Resolver::visit(stmt::If *stmt)
+{
+    resolve(stmt->m_condition.get());
+    resolve(stmt->m_then.get());
+    if (stmt->m_else.has_value()) resolve(stmt->m_else->get());
+}
+
+void Resolver::visit(stmt::Print *stmt)
+{
+    resolve(stmt->m_expr.get());
+}
+
+void Resolver::visit(stmt::Return *stmt)
+{
+    if (m_current_func == FunctionType::NONE)
+        ErrorHandler::get_instance().error(stmt->m_keyword, "Can't return from top-level code.");
+
+    if (stmt->m_value.has_value()) resolve(stmt->m_value->get());
+}
+
+void Resolver::visit(stmt::While *stmt)
+{
+    resolve(stmt->m_condition.get());
+    resolve(stmt->m_stmt.get());
+}
+
+Value Resolver::visit(expr::Variable *expr)
+{
+    if (m_scopes.empty())  return std::nullopt;
+
+    auto is_ready = m_scopes.back().find(expr->m_name.get_lexeme());
+    if (is_ready != m_scopes.back().end() && !is_ready->second)
+    {
+        cpplox::ErrorHandler::get_instance().error(expr->m_name, "Can't read local variable in its own initializer.");
+    }
+
+    resolve_local(expr, expr->m_name);
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Assign *expr)
+{
+    // resolve any variables that the assignment might contain
+    resolve(expr->m_value.get());
+    // resolve the variable that's being assigned to
+    resolve_local(expr, expr->m_name);
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Lambda *expr)
+{
+    begin_scope();
+    for (const Token &param : expr->m_params)
+    {
+        declare(param);
+        define(param);
+    }
+
+    resolve(expr->m_body);
+
+    end_scope();
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Binary *expr)
+{
+    resolve(expr->m_left.get());
+    resolve(expr->m_right.get());
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Call *expr)
+{
+    resolve(expr->m_callee.get());
+
+    for (const auto &arg : expr->m_args)
+    {
+        resolve(arg.get());
+    }
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Grouping *expr)
+{
+    resolve(expr->m_expression.get());
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Literal *expr)
+{
+    // there is nothing to resolve in a literal
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Logical *expr)
+{
+    resolve(expr->m_left.get());
+    resolve(expr->m_right.get());
+
+    return std::nullopt;
+}
+
+Value Resolver::visit(expr::Unary *expr)
+{
+    resolve(expr->m_right.get());
+
+    return std::nullopt;
+}
+
+void Resolver::resolve(const std::vector<StatementPtr> &stmts)
+{
+    for (const auto &stmt : stmts)
+    {
+        resolve(stmt.get());
+    }
+}
+
+void Resolver::resolve(stmt::Statement *stmt)
+{
+    stmt->accept(this);
+}
+
+void Resolver::resolve(expr::Expression *expr)
+{
+    expr->accept(this);
+}
+
+void Resolver::resolve_local(expr::Expression *expr, const Token &name)
+{
+    // how many scopes we had to traverse before we found the variable
+    int num_scopes = 0;
+    // we start iterating from the end,
+    // because we need to start from the innermost scope and continue outwards.
+    // if we don't find the variable we assume it's global
+    std::for_each(m_scopes.rbegin(), m_scopes.rend(), [&](const auto &scope) -> void {
+        if (scope.contains(name.get_lexeme()))
+        {
+            m_interpreter.lock()->resolve(expr, num_scopes);
+            return;
+        }
+        num_scopes++;
+    });
+}
+
+void Resolver::resolve_function(stmt::Function *function, FunctionType type)
+{
+    FunctionType enclosing_func = m_current_func;
+    m_current_func = type;
+
+    begin_scope();
+    for (const Token &param : function->m_params)
+    {
+        declare(param);
+        define(param);
+    }
+
+    resolve(function->m_body);
+
+    end_scope();
+
+    m_current_func = enclosing_func;
+}
+
+void Resolver::begin_scope()
+{
+    m_scopes.emplace_back(Scope{});
+}
+
+void Resolver::end_scope()
+{
+    m_scopes.pop_back();
+}
+
+void Resolver::declare(const Token &name)
+{
+    // the resolver skips any global variable declarations
+    if (m_scopes.empty()) return;
+
+    auto& scope = m_scopes.back();
+    if (scope.contains(name.get_lexeme()))
+    {
+        cpplox::ErrorHandler::get_instance().error(name, "Variable with this name is already declared in this scope.");
+    }
+
+    bool is_ready = false;
+    scope.emplace(name.get_lexeme(), is_ready);
+}
+
+void Resolver::define(const Token &name)
+{
+    // the resolver skips any global variable declarations
+    if (m_scopes.empty()) return;
+
+    bool is_ready = true;
+    m_scopes.back().at(name.get_lexeme()) = is_ready;
+}
+
+}

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -69,47 +69,47 @@ void Scanner::scan_token()
     switch (c)
     {
         case '(':
-            add_token(TokenType::LEFT_PAREN, std::nullopt);
+            add_token(TokenType::LEFT_PAREN);
             break;
         case ')':
-            add_token(TokenType::RIGHT_PAREN, std::nullopt);
+            add_token(TokenType::RIGHT_PAREN);
             break;
         case '{':
-            add_token(TokenType::LEFT_BRACE, std::nullopt);
+            add_token(TokenType::LEFT_BRACE);
             break;
         case '}':
-            add_token(TokenType::RIGHT_BRACE, std::nullopt);
+            add_token(TokenType::RIGHT_BRACE);
             break;
         case ',':
-            add_token(TokenType::COMMA, std::nullopt);
+            add_token(TokenType::COMMA);
             break;
         case '.':
-            add_token(TokenType::DOT, std::nullopt);
+            add_token(TokenType::DOT);
             break;
         case '-':
-            add_token(TokenType::MINUS, std::nullopt);
+            add_token(TokenType::MINUS);
             break;
         case '+':
-            add_token(TokenType::PLUS, std::nullopt);
+            add_token(TokenType::PLUS);
             break;
         case ';':
-            add_token(TokenType::SEMICOLON, std::nullopt);
+            add_token(TokenType::SEMICOLON);
             break;
         case '*':
-            add_token(TokenType::STAR, std::nullopt);
+            add_token(TokenType::STAR);
             break;
         case '!':
             // handle operators like !=, ==
-            add_token(match('=') ? TokenType::BANG_EQUAL : TokenType::BANG, std::nullopt);
+            add_token(match('=') ? TokenType::BANG_EQUAL : TokenType::BANG);
             break;
         case '=':
-            add_token(match('=') ? TokenType::EQUAL_EQUAL : TokenType::EQUAL, std::nullopt);
+            add_token(match('=') ? TokenType::EQUAL_EQUAL : TokenType::EQUAL);
             break;
         case '<':
-            add_token(match('=') ? TokenType::LESS_EQUAL : TokenType::LESS, std::nullopt);
+            add_token(match('=') ? TokenType::LESS_EQUAL : TokenType::LESS);
             break;
         case '>':
-            add_token(match('=') ? TokenType::GREATER_EQUAL : TokenType::GREATER, std::nullopt);
+            add_token(match('=') ? TokenType::GREATER_EQUAL : TokenType::GREATER);
             break;
         case '/':
             // if it's a comment - skip
@@ -123,7 +123,7 @@ void Scanner::scan_token()
                 block_comment();
             }
             else
-                add_token(TokenType::SLASH, std::nullopt);
+                add_token(TokenType::SLASH);
             break;
         case ' ':
         case '\r':
@@ -147,7 +147,6 @@ void Scanner::scan_token()
                 ErrorHandler::get_instance().error(m_line, m_column, c, m_str_line, "Unexpected character.");
             break;
     }
-
 }
 
 void Scanner::string()
@@ -216,7 +215,8 @@ void Scanner::block_comment()
         // if we run out of characters
         if (is_end())
         {
-            ErrorHandler::get_instance().error(m_line, m_column, m_source[m_current], m_str_line, "Unclosed block comment.");
+            ErrorHandler::get_instance().error(m_line, m_column, m_source[m_current], m_str_line,
+                                               "Unclosed block comment.");
             return;
         }
         if (peek() == '\n') m_line++;
@@ -261,11 +261,7 @@ bool Scanner::match(char expected)
 
 char Scanner::advance()
 {
-    if (m_source[m_current] == '\n')
-        m_column = 0;
-    else
-        m_column++;
-
+    update_column();
     return m_source.at(m_current++);
 }
 
@@ -284,16 +280,23 @@ char Scanner::peek_next()
 void Scanner::update_source_line()
 {
     // the character that starts new line
-    unsigned int new_line = m_current;
+    int new_line = m_current;
     for (char c : m_source.substr(m_current, m_source.size() - m_current))
     {
-        if (c == '\n')
-            break;
+        if (c == '\n') break;
         new_line++;
     }
 
     m_str_line = m_source.substr(m_current, new_line - m_current);
     m_new_line = new_line;
+}
+
+void Scanner::update_column()
+{
+    if (m_source[m_current] == '\n')
+        m_column = 0;
+    else
+        m_column++;
 }
 
 std::optional<TokenType> Scanner::str_to_keyword(const std::string& str)

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1,37 +1,43 @@
 #include "value.h"
+#include "error_handler.h"
 
 namespace cpplox
 {
 std::ostream& operator<<(std::ostream& stream, const Value& val)
 {
-    Val value = val.m_value;
-    if (!value.has_value()) return stream << "nil";
+    return stream << val.to_string();
+}
 
-    switch (value->index())
+std::string Value::to_string() const
+{
+    if (!m_value.has_value())
+        return "nil";
+
+    switch (m_value->index())
     {
         case 0:
-            return stream << std::get<std::string>(value.value());
+            return std::get<std::string>(m_value.value());
         case 1:
         {
-            std::string text = std::to_string(std::get<double>(value.value()));
+            std::string text = std::to_string(std::get<double>(m_value.value()));
             text = trim_zeroes(text);
-            return stream << text;
+            return text;
         }
         case 2:
         {
-            bool boolean = std::get<bool>(value.value());
-            if (boolean) return stream << "true";
-            return stream << "false";
+            bool boolean = std::get<bool>(m_value.value());
+            if (boolean) return "true";
+            return "false";
         }
         case 3:
         {
-            // TODO: add support for `Callable`
+            return std::get<std::shared_ptr<Callable>>(m_value.value())->to_string();
         }
         case std::variant_npos:
-            return stream << "nil";
+            return "nil";
         default:
-            std::cout << "Error: not every type was handled.";
-            return stream;
+            ErrorHandler::get_instance().debug_error("Error: not every type was handled.", __LINE__);
+            return "";
     }
 }
 


### PR DESCRIPTION
- Fixed a bug that caused variables that were captured in closures to change.
- Added `Resolver` class that acts as a static analyser. Right now it only resolves all variable usages.
- Added native `println()` function.
- Added `to_string()` method to `Callable` and its derived classes that prints a function value.
- Added `ErrorHandler::warning()` method that reports warnings.
- Changed `std::shared_ptr<Token>` to `Token` in syntax tree classes.
- Changed the formatting of debug errors.
- Replased all `unsigned int`s with `int`s.
- Added `Interpreter::register_native_funcs()` method.
- Moved `operator<<` in `value.h` to `Value::to_string()` method.
- `Scanner::add_token()` method now has a default parameter `std::nullopt` as a `literal` parameter.
- Added `const` to `Environment::get()` method.
- Comment formatting.