### PR TITLE
Added classes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@ AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortLambdasOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/include/class.h
+++ b/include/class.h
@@ -1,0 +1,48 @@
+#ifndef CLASS_H
+#define CLASS_H
+
+#include <memory>
+#include <unordered_map>
+
+#include "function.h"
+#include "instance.h"
+
+namespace cpplox
+{
+using MethodsMap = std::unordered_map<std::string, std::shared_ptr<Function>>;
+
+class Class : public Callable, public Instance
+{
+public:
+    Class(const std::string& name, const MethodsMap& methods)
+        : m_name(name)
+        , m_methods(methods)
+    {
+    }
+
+    // Callable
+    Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
+    [[nodiscard]] int arity() const override;
+    [[nodiscard]] inline std::string to_string() const override
+    {
+        return "<class " + m_name + ">";
+    }
+    [[nodiscard]] std::optional<std::shared_ptr<Function>> find_method(const std::string& name) const;
+
+    // Instance
+    Value get(const Token& name) override;
+    void set(const Token& name, const Value& value) override;
+
+    std::string m_name;
+
+private:
+    // A bad idea and a violation of some OOP practises,
+    // but I'll still go with it :)
+    using Instance::to_string;
+
+    MethodsMap m_methods;
+};
+
+}
+
+#endif  // CLASS_H

--- a/include/function.h
+++ b/include/function.h
@@ -11,19 +11,37 @@ namespace cpplox
 class Function : public Callable
 {
 public:
-    Function(const std::shared_ptr<ast::stmt::Function>& declaration, const std::shared_ptr<Environment>& closure)
-        : m_declaration(declaration)
+    Function(const std::shared_ptr<ast::stmt::Function>& declaration, const std::shared_ptr<Environment>& closure,
+             bool is_initializer = false, bool is_static = false)
+        : m_is_static(is_static)
+        , m_declaration(declaration)
         , m_closure(closure)
+        , m_is_initializer(is_initializer)
     {
     }
 
     Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
-    [[nodiscard]] int arity() const override;
-    [[nodiscard]] std::string to_string() const override;
+
+    [[nodiscard]] inline int arity() const override
+    {
+        return m_declaration->m_params.size();
+    }
+    [[nodiscard]] inline std::string to_string() const override
+    {
+        return "<fn " + m_declaration->m_name.get_lexeme() + ">";
+    }
+    // Bind `this` field to this function's closure.
+    // `this` represents the instance the function has been called on.
+    std::shared_ptr<Function> bind(const std::shared_ptr<Instance>& instance);
+
+    // Is this a static method on a class
+    const bool m_is_static = false;
 
 private:
     std::shared_ptr<ast::stmt::Function> m_declaration;
     std::shared_ptr<Environment> m_closure;
+
+    const bool m_is_initializer;
 };
 
 }

--- a/include/instance.h
+++ b/include/instance.h
@@ -1,0 +1,38 @@
+#ifndef INSTANCE_H
+#define INSTANCE_H
+
+#include <unordered_map>
+
+#include "error_handler.h"
+#include "token.h"
+#include "value.h"
+
+namespace cpplox
+{
+class Class;
+
+class Instance
+{
+public:
+    virtual ~Instance() = default;
+
+    // We need this constructor to not have to init Instance in Class constructor
+    Instance() = default;
+    explicit Instance(const std::shared_ptr<Class>& klass)
+        : m_class(klass)
+    {
+    }
+
+    virtual Value get(const Token& name);
+    virtual void set(const Token& name, const Value& value);
+
+    [[nodiscard]] std::string to_string() const;
+
+private:
+    std::shared_ptr<Class> m_class;
+    std::unordered_map<std::string, Value> m_fields;
+};
+
+}
+
+#endif  // INSTANCE_H

--- a/include/interpreter.h
+++ b/include/interpreter.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include "class.h"
 #include "environment.h"
 #include "error_handler.h"
 #include "fmt/core.h"
@@ -22,7 +23,6 @@ class Interpreter : public expr::Visitor, stmt::Visitor
 {
 public:
     Interpreter();
-    ~Interpreter() noexcept override;
 
     void interpret(std::vector<StatementPtr>& stmts);
 
@@ -36,6 +36,9 @@ public:
     Value visit(expr::Logical* expr) override;
     Value visit(expr::Call* expr) override;
     Value visit(expr::Lambda* expr) override;
+    Value visit(expr::Get* expr) override;
+    Value visit(expr::Set* expr) override;
+    Value visit(expr::This* expr) override;
 
     // statements
     void visit(stmt::Expression* stmt) override;
@@ -46,6 +49,7 @@ public:
     void visit(stmt::While* stmt) override;
     void visit(stmt::Function* stmt) override;
     void visit(stmt::Return* stmt) override;
+    void visit(stmt::Class* stmt) override;
 
     void execute_block(const std::vector<StatementPtr>& statements, const std::shared_ptr<Environment>& env);
     void resolve(expr::Expression* expr, int depth);

--- a/include/lambda.h
+++ b/include/lambda.h
@@ -2,8 +2,8 @@
 #define LAMBDA_H
 
 #include "callable.h"
-#include "syntax_tree/expression.h"
 #include "environment.h"
+#include "syntax_tree/expression.h"
 
 namespace cpplox
 {
@@ -16,8 +16,14 @@ public:
     }
 
     Value call(Interpreter* interpreter, const std::vector<Value>& args) override;
-    [[nodiscard]] int arity() const override;
-    [[nodiscard]] std::string to_string() const override;
+    [[nodiscard]] inline int arity() const override
+    {
+        return m_declaration->m_params.size();
+    }
+    [[nodiscard]] inline std::string to_string() const override
+    {
+        return "<fn lambda>";
+    }
 
 private:
     std::shared_ptr<ast::expr::Lambda> m_declaration;

--- a/include/parser.h
+++ b/include/parser.h
@@ -45,6 +45,7 @@ private:
     ExpressionPtr primary();
 
     StatementPtr declaration();
+    StatementPtr class_declaration();
     // `kind` represents the kind of declaration parsed -
     // a function or a method
     StatementPtr function(const std::string& kind);
@@ -82,6 +83,8 @@ private:
     ParseError error(const Token& token, const std::string& msg);
     // Advances the input to the statement boundary in the process of error recovery
     void synchronize();
+    // Check if a prefix has already been added to the function's list of prefixes
+    bool is_prefix_added(const std::vector<Token>& prefixes, const Token& prefix) const;
 
     const std::vector<Token> m_tokens;
     int m_current = 0;

--- a/include/syntax_tree/expression.h
+++ b/include/syntax_tree/expression.h
@@ -22,6 +22,9 @@ class Assign;
 class Logical;
 class Call;
 class Lambda;
+class Get;
+class Set;
+class This;
 
 // Interface that represents an operation executed on the given expressions
 class Visitor
@@ -36,6 +39,9 @@ public:
     virtual Value visit(Logical* expr) = 0;
     virtual Value visit(Call* expr) = 0;
     virtual Value visit(Lambda* expr) = 0;
+    virtual Value visit(Get* expr) = 0;
+    virtual Value visit(Set* expr) = 0;
+    virtual Value visit(This* expr) = 0;
 
 protected:
     virtual ~Visitor() = default;
@@ -213,6 +219,60 @@ public:
 
     std::vector<Token> m_params;
     std::vector<std::shared_ptr<cpplox::ast::stmt::Statement>> m_body;
+};
+
+class Get : public Expression
+{
+public:
+    Get(const std::shared_ptr<Expression>& object, const Token& name)
+        : m_object(object)
+        , m_name(name)
+    {
+    }
+
+    Value accept(Visitor* visitor) override
+    {
+        return visitor->visit(this);
+    }
+
+    std::shared_ptr<Expression> m_object;
+    Token m_name;
+};
+
+class Set : public Expression
+{
+public:
+    Set(const std::shared_ptr<Expression>& object, const Token& name, const std::shared_ptr<Expression>& value)
+        : m_object(object)
+        , m_name(name)
+        , m_value(value)
+    {
+    }
+
+    Value accept(Visitor* visitor) override
+    {
+        return visitor->visit(this);
+    }
+
+    std::shared_ptr<Expression> m_object;
+    Token m_name;
+    std::shared_ptr<Expression> m_value;
+};
+
+class This : public Expression
+{
+public:
+    explicit This(const Token& keyword)
+        : m_keyword(keyword)
+    {
+    }
+
+    Value accept(Visitor* visitor) override
+    {
+        return visitor->visit(this);
+    }
+
+    Token m_keyword;
 };
 
 }

--- a/include/syntax_tree/statement.h
+++ b/include/syntax_tree/statement.h
@@ -13,6 +13,7 @@ class If;
 class While;
 class Function;
 class Return;
+class Class;
 
 // Interface that represents an operation executed on the given statements
 class Visitor
@@ -27,6 +28,7 @@ public:
     virtual void visit(While* stmt) = 0;
     virtual void visit(Function* stmt) = 0;
     virtual void visit(Return* stmt) = 0;
+    virtual void visit(Class* stmt) = 0;
 
 protected:
     virtual ~Visitor() = default;
@@ -153,11 +155,11 @@ public:
 class Function : public Statement
 {
 public:
-    Function(const Token& name, const std::vector<Token>& params,
-             const std::vector<std::shared_ptr<Statement>>& body)
+    Function(const Token& name, const std::vector<Token>& params, const std::vector<std::shared_ptr<Statement>>& body, const std::vector<Token>& prefix)
         : m_name(name)
         , m_params(params)
         , m_body(body)
+        , m_prefix(prefix)
     {
     }
 
@@ -169,6 +171,8 @@ public:
     Token m_name;
     std::vector<Token> m_params;
     std::vector<std::shared_ptr<Statement>> m_body;
+    // Optional keywords that appear before function name
+    std::vector<Token> m_prefix;
 };
 
 class Return : public Statement
@@ -187,6 +191,24 @@ public:
 
     Token m_keyword;
     std::optional<ExpressionPtr> m_value;
+};
+
+class Class : public Statement
+{
+public:
+    Class(const Token& name, const std::vector<std::shared_ptr<stmt::Function>>& methods)
+        : m_name(name)
+        , m_methods(methods)
+    {
+    }
+
+    void accept(Visitor* visitor) override
+    {
+        return visitor->visit(this);
+    }
+
+    Token m_name;
+    std::vector<std::shared_ptr<stmt::Function>> m_methods;
 };
 }
 

--- a/include/token.h
+++ b/include/token.h
@@ -56,6 +56,8 @@ enum class TokenType
     VAR,
     WHILE,
 
+    PREFIX,
+
     cpplox_EOF
 };
 
@@ -96,6 +98,15 @@ public:
     [[nodiscard]] inline int get_column() const
     {
         return m_column;
+    }
+
+    friend inline bool operator==(const Token& lhs, const Token& rhs)
+    {
+        return lhs.m_token_type == rhs.m_token_type && lhs.m_lexeme == rhs.m_lexeme;
+    }
+    friend inline bool operator==(const Token& lhs, const std::string& rhs)
+    {
+        return lhs.m_lexeme == rhs;
     }
 
 private:

--- a/include/value.h
+++ b/include/value.h
@@ -10,7 +10,10 @@
 
 namespace cpplox
 {
-using Val = std::optional<std::variant<std::string, double, bool, std::shared_ptr<Callable>>>;
+class Instance;
+
+using Val =
+    std::optional<std::variant<std::string, double, bool, std::shared_ptr<Callable>, std::shared_ptr<Instance>>>;
 
 class Value
 {
@@ -33,6 +36,10 @@ public:
     {
     }
     Value(const std::shared_ptr<Callable>& value)
+        : m_value(value)
+    {
+    }
+    Value(const std::shared_ptr<Instance>& value)
         : m_value(value)
     {
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
- target_sources(cpplox PRIVATE main.cpp scanner.cpp error_handler.cpp value.cpp parser.cpp interpreter.cpp environment.cpp function.cpp lambda.cpp resolver.cpp)
+ target_sources(cpplox PRIVATE main.cpp scanner.cpp error_handler.cpp value.cpp parser.cpp interpreter.cpp environment.cpp function.cpp lambda.cpp resolver.cpp class.cpp instance.cpp)
 
  add_subdirectory(native_functions)

--- a/src/class.cpp
+++ b/src/class.cpp
@@ -1,0 +1,62 @@
+#include "class.h"
+
+#include "instance.h"
+#include "interpreter.h"
+
+namespace cpplox
+{
+Value Class::call(Interpreter *interpreter, const std::vector<Value> &args)
+{
+    auto instance = std::make_shared<Instance>(std::make_shared<Class>(*this));
+    // constructor
+    std::optional<std::shared_ptr<Function>> initializer = find_method("init");
+    if (initializer.has_value())
+    {
+        initializer.value()->bind(instance)->call(interpreter, args);
+    }
+
+    return instance;
+}
+
+int Class::arity() const
+{
+    std::optional<std::shared_ptr<Function>> initializer = find_method("init");
+    if (!initializer.has_value())
+        return 0;
+
+    return initializer.value()->arity();
+}
+
+std::optional<std::shared_ptr<Function>> Class::find_method(const std::string &name) const
+{
+    if (m_methods.contains(name))
+    {
+        return m_methods.at(name);
+    }
+
+    return std::nullopt;
+}
+
+Value Class::get(const Token &name)
+{
+    auto method = find_method(name.get_lexeme());
+    if (method.has_value())
+    {
+        if (method.value()->m_is_static)
+        {
+            auto this_ptr = std::make_shared<Instance>(*this);
+            return std::dynamic_pointer_cast<Callable>(method.value()->bind(this_ptr));
+        }
+        else
+            throw RuntimeError{name, "Only static methods can be called from a class."};
+    }
+
+    throw RuntimeError{name, "Undefined method '" + name.get_lexeme() + "'."};
+}
+
+void Class::set(const Token &name, const Value &value)
+{
+    throw RuntimeError{name, "Can't set properties on a class."};
+}
+
+}

--- a/src/error_handler.cpp
+++ b/src/error_handler.cpp
@@ -19,7 +19,7 @@ void ErrorHandler::error(const Token& token, const std::string& msg)
     if (token.get_token_type() == TokenType::cpplox_EOF)
         report(token.get_line(), token.get_column(), " at end", formatted_line, msg);
     else
-        report(token.get_line(), token.get_column(), "at '" + token.get_lexeme() + "'", formatted_line, msg);
+        report(token.get_line(), token.get_column(), token.get_lexeme(), formatted_line, msg);
 }
 
 void ErrorHandler::error(int line, int column, char character, const std::string& src_str,
@@ -54,13 +54,14 @@ std::string ErrorHandler::format_error(const Token& token)
     // I separated the line into multiple variables
     // because I wanted the token to be colored differently from the rest of the line
 
+    // TODO: make the error token different color from the rest of the line.
     // part of the line before the token that caused the error
     int column = token.get_column();
     std::string before_token_line =
         fmt::format(fg(fmt::color::dark_olive_green), "{}", source_line.substr(0, column - token.get_lexeme().size()));
     std::string token_str = fmt::format(fg(fmt::color::red), "{}", token.get_lexeme());
-    std::string after_token_line = fmt::format(fg(fmt::color::dark_olive_green), "{}", source_line.substr(column),
-                                               source_line.size() - column);
+    std::string after_token_line = fmt::format(fg(fmt::color::dark_olive_green), "{}", source_line.substr(column,
+                                               source_line.size() - column));
 
     return before_token_line + token_str + after_token_line;
 }
@@ -69,7 +70,9 @@ void ErrorHandler::report(int line, int column, const std::string& where, const 
                           const std::string& msg)
 {
     fmt::print("\n[{}, {}]", line, column);
-    fmt::print(fmt::emphasis::italic | fg(fmt::color::red), " Error {}: {}\n\n", where, msg);
+    fmt::print(fmt::emphasis::italic | fg(fmt::color::red), " Error at '");
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::white), "{}", where);
+    fmt::print(fmt::emphasis::italic | fg(fmt::color::red), "': {}\n\n", msg);
     fmt::print(fg(fmt::color::dark_olive_green), "\t{}\n\n", src_str);
     m_had_error = true;
 }

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -20,19 +20,24 @@ Value Function::call(Interpreter *interpreter, const std::vector<Value> &args)
     }
     catch (Return &return_value)
     {
+        // allow using `return;` in initializers
+        if (m_is_initializer)
+            return m_closure->get_at(0, "this");
+
         return return_value.m_value;
     }
+
+    if (m_is_initializer)
+        return m_closure->get_at(0, "this");
+
     return std::nullopt;
 }
 
-int Function::arity() const
+std::shared_ptr<Function> Function::bind(const std::shared_ptr<Instance> &instance)
 {
-    return m_declaration->m_params.size();
-}
-
-std::string Function::to_string() const
-{
-    return "<fn " + m_declaration->m_name.get_lexeme() + ">";
+    auto env = std::make_shared<Environment>(m_closure);
+    env->define("this", instance);
+    return std::make_shared<Function>(m_declaration, env, m_is_initializer, m_is_static);
 }
 
 }

--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -1,0 +1,41 @@
+#include "instance.h"
+
+#include "class.h"
+
+namespace cpplox
+{
+Value Instance::get(const Token& name)
+{
+    if (m_fields.contains(name.get_lexeme()))
+        return m_fields.at(name.get_lexeme());
+
+    auto method = m_class->find_method(name.get_lexeme());
+    if (method.has_value())
+    {
+        auto this_ptr = std::make_shared<Instance>(*this);
+        return std::dynamic_pointer_cast<Callable>(method.value()->bind(this_ptr));
+    }
+
+    throw RuntimeError{name, "Undefined property '" + name.get_lexeme() + "'."};
+}
+
+void Instance::set(const Token& name, const Value& value)
+{
+    auto field = m_fields.find(name.get_lexeme());
+    if (field != m_fields.end())
+    {
+        field->second = value;
+    }
+    else
+    {
+        // cpplox allows creating new fields on instances
+        m_fields.emplace(name.get_lexeme(), value);
+    }
+}
+
+std::string Instance::to_string() const
+{
+    return "<instance " + m_class->m_name + ">";
+}
+
+}

--- a/src/lambda.cpp
+++ b/src/lambda.cpp
@@ -25,14 +25,4 @@ Value Lambda::call(Interpreter *interpreter, const std::vector<Value> &args)
     return std::nullopt;
 }
 
-int Lambda::arity() const
-{
-    return m_declaration->m_params.size();
-}
-
-std::string Lambda::to_string() const
-{
-    return "<fn lambda>";
-}
-
 }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -17,8 +17,10 @@ std::optional<std::vector<Token>> Scanner::run_file(const std::string& filename)
         // scan the m_source that contains the script file contents
         run();
 
-        if (ErrorHandler::get_instance().m_had_error) std::exit(65);
-        if (ErrorHandler::get_instance().m_had_runtime_error) std::exit(70);
+        if (ErrorHandler::get_instance().m_had_error)
+            std::exit(65);
+        if (ErrorHandler::get_instance().m_had_runtime_error)
+            std::exit(70);
 
         return m_tokens;
     }
@@ -139,7 +141,8 @@ void Scanner::scan_token()
             break;
         default:
             // we encountered a number literal
-            if (std::isdigit(c)) number();
+            if (std::isdigit(c))
+                number();
             // we encountered an identifier
             else if (std::isalpha(c))
                 identifier();
@@ -154,7 +157,8 @@ void Scanner::string()
     // advance the input until you encounter the closing quote or the end of file
     while (peek() != '"' && !is_end())
     {
-        if (peek() == '\n') m_line++;
+        if (peek() == '\n')
+            m_line++;
         advance();
     }
 
@@ -219,7 +223,8 @@ void Scanner::block_comment()
                                                "Unclosed block comment.");
             return;
         }
-        if (peek() == '\n') m_line++;
+        if (peek() == '\n')
+            m_line++;
         // handle nested comments
         if (peek_next() == '*')
             if (peek() == '/')
@@ -252,8 +257,10 @@ bool Scanner::is_end() const
 
 bool Scanner::match(char expected)
 {
-    if (is_end()) return false;
-    if (m_source.at(m_current) != expected) return false;
+    if (is_end())
+        return false;
+    if (m_source.at(m_current) != expected)
+        return false;
 
     m_current++;
     return true;
@@ -267,13 +274,15 @@ char Scanner::advance()
 
 char Scanner::peek()
 {
-    if (is_end()) return '\0';
+    if (is_end())
+        return '\0';
     return m_source.at(m_current);
 }
 
 char Scanner::peek_next()
 {
-    if (m_current + 1 >= m_source.size()) return '\0';
+    if (m_current + 1 >= m_source.size())
+        return '\0';
     return m_source.at(m_current + 1);
 }
 
@@ -283,7 +292,8 @@ void Scanner::update_source_line()
     int new_line = m_current;
     for (char c : m_source.substr(m_current, m_source.size() - m_current))
     {
-        if (c == '\n') break;
+        if (c == '\n')
+            break;
         new_line++;
     }
 
@@ -307,7 +317,7 @@ std::optional<TokenType> Scanner::str_to_keyword(const std::string& str)
         {"if", TokenType::IF},       {"nil", TokenType::NIL},       {"or", TokenType::OR},
         {"print", TokenType::PRINT}, {"return", TokenType::RETURN}, {"super", TokenType::SUPER},
         {"this", TokenType::THIS},   {"true", TokenType::TRUE},     {"var", TokenType::VAR},
-        {"while", TokenType::WHILE}};
+        {"while", TokenType::WHILE}, {"static", TokenType::PREFIX}};
 
     if (keyword_lookup.contains(str))
     {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -1,5 +1,7 @@
 #include "value.h"
+
 #include "error_handler.h"
+#include "instance.h"
 
 namespace cpplox
 {
@@ -10,8 +12,7 @@ std::ostream& operator<<(std::ostream& stream, const Value& val)
 
 std::string Value::to_string() const
 {
-    if (!m_value.has_value())
-        return "nil";
+    if (!m_value.has_value()) return "nil";
 
     switch (m_value->index())
     {
@@ -32,6 +33,10 @@ std::string Value::to_string() const
         case 3:
         {
             return std::get<std::shared_ptr<Callable>>(m_value.value())->to_string();
+        }
+        case 4:
+        {
+            return std::get<std::shared_ptr<Instance>>(m_value.value())->to_string();
         }
         case std::variant_npos:
             return "nil";


### PR DESCRIPTION
Added classes, instances, constructors.
Added static methods on classes.
Added `this` expressions.
Moved `lambda()` call to `assignment()` in `Parser`.
`Resolver` now checks proper use of `static` prefix.
Removed useless `Interpreter::~Interpreter()`.
The problematic token is now colored white in a reported error.
Moved some `Lambda` methods to a header file and made them `inline`.
Fixed a parenthesis `ErrorHandler::format_error()`. Altough nothing changed after that.
Formatting.

Changed .clang-format to prohibit short if statements on a single line.